### PR TITLE
Change badge to new Travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # value_ptr
 
-[![Build Status](https://travis-ci.org/Baltoli/value_ptr.svg?branch=master)](https://travis-ci.org/Baltoli/value_ptr)
+[![Build Status](https://travis-ci.com/Baltoli/value_ptr.svg?branch=master)](https://travis-ci.com/Baltoli/value_ptr)
 
 Header-only library implementing a smart pointer with value semantics


### PR DESCRIPTION
CI has migrated over to travis-ci.com - changes the badge to reflect this.