### PR TITLE
Add support for custom deleters

### DIFF
--- a/include/value_ptr/value_ptr.h
+++ b/include/value_ptr/value_ptr.h
@@ -255,118 +255,118 @@ protected:
   pmr_concept* impl_;
 };
 
-template <typename T1, typename T2>
-bool operator==(value_ptr<T1> const& a, value_ptr<T2> const& b)
+template <typename T1, typename T2, typename D1, typename D2>
+bool operator==(value_ptr<T1, D1> const& a, value_ptr<T2, D2> const& b)
 {
   return a.get() == b.get();
 }
 
-template <typename T1, typename T2>
-bool operator!=(value_ptr<T1> const& a, value_ptr<T2> const& b)
+template <typename T1, typename T2, typename D1, typename D2>
+bool operator!=(value_ptr<T1, D1> const& a, value_ptr<T2, D2> const& b)
 {
   return a.get() != b.get();
 }
 
-template <typename T1, typename T2>
-bool operator<(value_ptr<T1> const& a, value_ptr<T2> const& b)
+template <typename T1, typename T2, typename D1, typename D2>
+bool operator<(value_ptr<T1, D1> const& a, value_ptr<T2, D2> const& b)
 {
-  using CT = typename std::common_type<typename value_ptr<T1>::pointer,
-      typename value_ptr<T2>::pointer>::type;
+  using CT = typename std::common_type<typename value_ptr<T1, D1>::pointer,
+      typename value_ptr<T2, D2>::pointer>::type;
   return std::less<CT>()(a.get(), b.get());
 }
 
-template <typename T1, typename T2>
-bool operator<=(value_ptr<T1> const& a, value_ptr<T2> const& b)
+template <typename T1, typename T2, typename D1, typename D2>
+bool operator<=(value_ptr<T1, D1> const& a, value_ptr<T2, D2> const& b)
 {
   return !(b < a);
 }
 
-template <typename T1, typename T2>
-bool operator>(value_ptr<T1> const& a, value_ptr<T2> const& b)
+template <typename T1, typename T2, typename D1, typename D2>
+bool operator>(value_ptr<T1, D1> const& a, value_ptr<T2, D2> const& b)
 {
   return b < a;
 }
 
-template <typename T1, typename T2>
-bool operator>=(value_ptr<T1> const& a, value_ptr<T2> const& b)
+template <typename T1, typename T2, typename D1, typename D2>
+bool operator>=(value_ptr<T1, D1> const& a, value_ptr<T2, D2> const& b)
 {
   return !(a < b);
 }
 
-template <typename T>
-bool operator==(value_ptr<T> const& a, std::nullptr_t)
+template <typename T, typename D>
+bool operator==(value_ptr<T, D> const& a, std::nullptr_t)
 {
   return !a;
 }
 
-template <typename T>
-bool operator==(std::nullptr_t, value_ptr<T> const& a)
+template <typename T, typename D>
+bool operator==(std::nullptr_t, value_ptr<T, D> const& a)
 {
   return !a;
 }
 
-template <typename T>
-bool operator!=(value_ptr<T> const& a, std::nullptr_t)
+template <typename T, typename D>
+bool operator!=(value_ptr<T, D> const& a, std::nullptr_t)
 {
   return (bool)a;
 }
 
-template <typename T>
-bool operator!=(std::nullptr_t, value_ptr<T> const& a)
+template <typename T, typename D>
+bool operator!=(std::nullptr_t, value_ptr<T, D> const& a)
 {
   return (bool)a;
 }
 
-template <typename T>
-bool operator<(value_ptr<T> const& a, std::nullptr_t)
+template <typename T, typename D>
+bool operator<(value_ptr<T, D> const& a, std::nullptr_t)
 {
-  return std::less<typename value_ptr<T>::pointer>()(a.get(), nullptr);
+  return std::less<typename value_ptr<T, D>::pointer>()(a.get(), nullptr);
 }
 
-template <typename T>
-bool operator<(std::nullptr_t, value_ptr<T> const& a)
+template <typename T, typename D>
+bool operator<(std::nullptr_t, value_ptr<T, D> const& a)
 {
-  return std::less<typename value_ptr<T>::pointer>()(nullptr, a.get());
+  return std::less<typename value_ptr<T, D>::pointer>()(nullptr, a.get());
 }
 
-template <typename T>
-bool operator<=(value_ptr<T> const& a, std::nullptr_t)
+template <typename T, typename D>
+bool operator<=(value_ptr<T, D> const& a, std::nullptr_t)
 {
   return !(nullptr < a);
 }
 
-template <typename T>
-bool operator<=(std::nullptr_t, value_ptr<T> const& a)
+template <typename T, typename D>
+bool operator<=(std::nullptr_t, value_ptr<T, D> const& a)
 {
   return !(a < nullptr);
 }
 
-template <typename T>
-bool operator>(value_ptr<T> const& a, std::nullptr_t)
+template <typename T, typename D>
+bool operator>(value_ptr<T, D> const& a, std::nullptr_t)
 {
   return nullptr < a;
 }
 
-template <typename T>
-bool operator>(std::nullptr_t, value_ptr<T> const& a)
+template <typename T, typename D>
+bool operator>(std::nullptr_t, value_ptr<T, D> const& a)
 {
   return a < nullptr;
 }
 
-template <typename T>
-bool operator>=(value_ptr<T> const& a, std::nullptr_t)
+template <typename T, typename D>
+bool operator>=(value_ptr<T, D> const& a, std::nullptr_t)
 {
   return !(a < nullptr);
 }
 
-template <typename T>
-bool operator>=(std::nullptr_t, value_ptr<T> const& a)
+template <typename T, typename D>
+bool operator>=(std::nullptr_t, value_ptr<T, D> const& a)
 {
   return !(nullptr < a);
 }
 
-template <typename T>
-void swap(value_ptr<T>& a, value_ptr<T>& b)
+template <typename T, typename D>
+void swap(value_ptr<T, D>& a, value_ptr<T, D>& b)
 {
   a.swap(b);
 }
@@ -380,11 +380,11 @@ auto make_val(Args&&... args) -> value_ptr<T>
 
 namespace std {
 
-template <typename T>
-struct hash<bsc::value_ptr<T>> {
-  std::size_t operator()(bsc::value_ptr<T> const& ptr) const
+template <typename T, typename D>
+struct hash<bsc::value_ptr<T, D>> {
+  std::size_t operator()(bsc::value_ptr<T, D> const& ptr) const
   {
-    return std::hash<typename bsc::value_ptr<T>::pointer>()(ptr.get());
+    return std::hash<typename bsc::value_ptr<T, D>::pointer>()(ptr.get());
   }
 };
 } // namespace std

--- a/include/value_ptr/value_ptr.h
+++ b/include/value_ptr/value_ptr.h
@@ -132,8 +132,10 @@ public:
   {
   }
 
+  // TODO: requirements on the copy-construtibility of deleters
   value_ptr(value_ptr<T> const& other)
-      : impl_(other.impl_ ? other.impl_->clone() : nullptr)
+      : deleter_(other.deleter_)
+      , impl_(other.impl_ ? other.impl_->clone() : nullptr)
   {
   }
 
@@ -144,8 +146,10 @@ public:
     return *this;
   }
 
+  // TODO: requirements on the move-construtibility of deleters
   value_ptr(value_ptr<T>&& other)
-      : impl_(std::move(other.impl_))
+      : deleter_(std::move(other.deleter_))
+      , impl_(std::move(other.impl_))
   {
     other.impl_ = nullptr;
   }
@@ -186,6 +190,12 @@ public:
    * otherwise).
    */
   explicit operator bool() const { return static_cast<bool>(impl_); }
+
+  /*
+   * Get the deleter object responsible for deleting managed objects.
+   */
+  Deleter& get_deleter() { return deleter_; }
+  Deleter const& get_deleter() const { return deleter_; }
 
   /**
    * Get the underlying raw pointer and release ownership.
@@ -228,6 +238,7 @@ public:
   {
     using std::swap;
     swap(impl_, other.impl_);
+    swap(deleter_, other.deleter_);
   }
 
   /**

--- a/include/value_ptr/value_ptr.h
+++ b/include/value_ptr/value_ptr.h
@@ -84,9 +84,13 @@ public:
    *
    * This constructor takes ownership of the pointer passed to it.
    */
-  template <typename U>
+  template <typename U,
+      typename
+      = typename std::enable_if<std::is_default_constructible<Deleter>::value
+          && !std::is_pointer<Deleter>::value>::type>
   explicit value_ptr(U* ptr)
-      : impl_(new pmr_model<U>(ptr, deleter_))
+      : deleter_()
+      , impl_(new pmr_model<U>(ptr, deleter_))
   {
   }
 
@@ -107,8 +111,12 @@ public:
   /**
    * Construct a value_ptr from nullptr.
    */
+  template <typename
+      = typename std::enable_if<std::is_default_constructible<Deleter>::value
+          && !std::is_pointer<Deleter>::value>::type>
   value_ptr(std::nullptr_t)
-      : impl_(nullptr)
+      : deleter_()
+      , impl_(nullptr)
   {
   }
 
@@ -116,6 +124,9 @@ public:
    * Default-constructing a value_ptr is equivalent to constructing with
    * nullptr.
    */
+  template <typename
+      = typename std::enable_if<std::is_default_constructible<Deleter>::value
+          && !std::is_pointer<Deleter>::value>::type>
   value_ptr()
       : value_ptr(nullptr)
   {

--- a/include/value_ptr/value_ptr.h
+++ b/include/value_ptr/value_ptr.h
@@ -246,7 +246,10 @@ public:
    *
    * After calling, this object will be reset as if release had been called.
    */
-  std::unique_ptr<T> to_unique() { return std::unique_ptr<T>(release()); }
+  std::unique_ptr<T> to_unique()
+  {
+    return std::unique_ptr<T, Deleter>(release(), deleter_);
+  }
 
 protected:
   pmr_concept* impl_;

--- a/include/value_ptr/value_ptr.h
+++ b/include/value_ptr/value_ptr.h
@@ -41,7 +41,7 @@ private:
     virtual T* release() = 0;
   };
 
-  template <typename D>
+  template <typename D, typename ModelDeleter>
   struct pmr_model : pmr_concept {
     pmr_model(D* ptr)
         : ptr_(ptr)
@@ -55,7 +55,10 @@ private:
       }
     }
 
-    pmr_model<D>* clone() override { return new pmr_model<D>(new D(*ptr_)); }
+    pmr_model<D, ModelDeleter>* clone() override
+    {
+      return new pmr_model<D, ModelDeleter>(new D(*ptr_));
+    }
 
     D* get() override { return ptr_; }
 
@@ -79,7 +82,7 @@ public:
    */
   template <typename U>
   explicit value_ptr(U* ptr)
-      : impl_(new pmr_model<U>(ptr))
+      : impl_(new pmr_model<U, Deleter>(ptr))
   {
   }
 
@@ -93,7 +96,7 @@ public:
   value_ptr(value_ptr<U> other)
   {
     auto clone = other.impl_->clone();
-    impl_ = new pmr_model<U>(clone->release());
+    impl_ = new pmr_model<U, Deleter>(clone->release());
     delete clone;
   }
 
@@ -197,7 +200,7 @@ public:
     }
 
     if (ptr) {
-      impl_ = new pmr_model<T>(ptr);
+      impl_ = new pmr_model<T, Deleter>(ptr);
     } else {
       impl_ = nullptr;
     }

--- a/include/value_ptr/value_ptr.h
+++ b/include/value_ptr/value_ptr.h
@@ -39,9 +39,11 @@ private:
     virtual T* get() = 0;
     virtual T& operator*() = 0;
     virtual T* release() = 0;
+
+    /* virtual Deleter& deleter() = 0; */
   };
 
-  template <typename D, typename ModelDeleter>
+  template <typename D>
   struct pmr_model : pmr_concept {
     pmr_model(D* ptr)
         : ptr_(ptr)
@@ -55,10 +57,7 @@ private:
       }
     }
 
-    pmr_model<D, ModelDeleter>* clone() override
-    {
-      return new pmr_model<D, ModelDeleter>(new D(*ptr_));
-    }
+    pmr_model<D>* clone() override { return new pmr_model<D>(new D(*ptr_)); }
 
     D* get() override { return ptr_; }
 
@@ -96,7 +95,7 @@ public:
   value_ptr(value_ptr<U> other)
   {
     auto clone = other.impl_->clone();
-    impl_ = new pmr_model<U, Deleter>(clone->release());
+    impl_ = new pmr_model<U>(clone->release());
     delete clone;
   }
 
@@ -200,7 +199,7 @@ public:
     }
 
     if (ptr) {
-      impl_ = new pmr_model<T, Deleter>(ptr);
+      impl_ = new pmr_model<T>(ptr);
     } else {
       impl_ = nullptr;
     }

--- a/include/value_ptr/value_ptr.h
+++ b/include/value_ptr/value_ptr.h
@@ -139,7 +139,7 @@ public:
   {
   }
 
-  value_ptr<T>& operator=(value_ptr<T> other)
+  value_ptr<T, Deleter>& operator=(value_ptr<T, Deleter> other)
   {
     using std::swap;
     swap(*this, other);
@@ -147,14 +147,14 @@ public:
   }
 
   // TODO: requirements on the move-construtibility of deleters
-  value_ptr(value_ptr<T>&& other)
+  value_ptr(value_ptr<T, Deleter>&& other)
       : deleter_(std::move(other.deleter_))
       , impl_(std::move(other.impl_))
   {
     other.impl_ = nullptr;
   }
 
-  value_ptr<T>& operator=(std::nullptr_t)
+  value_ptr<T, Deleter>& operator=(std::nullptr_t)
   {
     reset();
     return *this;
@@ -234,7 +234,7 @@ public:
   /**
    * Specialization to enable ADL swap.
    */
-  void swap(value_ptr<T>& other)
+  void swap(value_ptr<T, Deleter>& other)
   {
     using std::swap;
     swap(impl_, other.impl_);
@@ -246,7 +246,7 @@ public:
    *
    * After calling, this object will be reset as if release had been called.
    */
-  std::unique_ptr<T> to_unique()
+  std::unique_ptr<T, Deleter> to_unique()
   {
     return std::unique_ptr<T, Deleter>(release(), deleter_);
   }

--- a/include/value_ptr/value_ptr.h
+++ b/include/value_ptr/value_ptr.h
@@ -20,7 +20,7 @@ namespace bsc {
 /**
  * Smart pointer class with value semantics.
  */
-template <typename T>
+template <typename T, typename Deleter = std::default_delete<T>>
 class value_ptr {
 public:
   /**
@@ -28,7 +28,7 @@ public:
    */
   using pointer = T*;
 
-  template <typename U>
+  template <typename, typename>
   friend class value_ptr;
 
 private:

--- a/test/deleters.cpp
+++ b/test/deleters.cpp
@@ -1,0 +1,1 @@
+#include "catch.hpp"

--- a/test/deleters.cpp
+++ b/test/deleters.cpp
@@ -15,19 +15,38 @@ struct nrc {
 
   int& c_;
 };
+
+struct nrc_delete {
+  nrc_delete() = default;
+
+  void operator()(nrc *n) const { n->c_--; }
+};
 // clang-format on
 
 TEST_CASE("counts don't get reset by default")
 {
   int count = 0;
   {
-    auto v = value_ptr<nrc>(new nrc(count));
+    auto v = make_val<nrc>(count);
   }
   REQUIRE(count == 1);
 
-  auto v2 = new value_ptr<nrc>(new nrc(count));
+  auto v2 = make_val<nrc>(count);
   REQUIRE(count == 2);
-  delete v2;
+}
 
-  REQUIRE(count == 2);
+TEST_CASE("counts get reset if using a custom deleter")
+{
+  int count = 0;
+  {
+    auto v = value_ptr<nrc, nrc_delete>(new nrc(count));
+    REQUIRE(count == 1);
+
+    auto v2 = v;
+    REQUIRE(count == 2);
+
+    auto v3 = std::move(v2);
+    REQUIRE(count == 2);
+  }
+  REQUIRE(count == 0);
 }

--- a/test/deleters.cpp
+++ b/test/deleters.cpp
@@ -5,3 +5,29 @@
 #include <iostream>
 
 using namespace bsc;
+
+// clang-format off
+struct nrc {
+  nrc(int& c) : c_(c) { ++c_; }
+  nrc(nrc const& o) : nrc(o.c_) {}
+  nrc(nrc&&) = delete;
+  ~nrc() = default;
+
+  int& c_;
+};
+// clang-format on
+
+TEST_CASE("counts don't get reset by default")
+{
+  int count = 0;
+  {
+    auto v = value_ptr<nrc>(new nrc(count));
+  }
+  REQUIRE(count == 1);
+
+  auto v2 = new value_ptr<nrc>(new nrc(count));
+  REQUIRE(count == 2);
+  delete v2;
+
+  REQUIRE(count == 2);
+}

--- a/test/deleters.cpp
+++ b/test/deleters.cpp
@@ -1,1 +1,7 @@
 #include "catch.hpp"
+
+#include <value_ptr/value_ptr.h>
+
+#include <iostream>
+
+using namespace bsc;

--- a/test/unit/value_ptr.cpp
+++ b/test/unit/value_ptr.cpp
@@ -14,6 +14,7 @@ using namespace bsc;
 struct rc {
   rc(int& c) : c_(c) { ++c_; }
   rc(rc const& o) : rc(o.c_) {}
+  rc(rc&&) = delete;
   ~rc() { --c_; }
 
   int& c_;


### PR DESCRIPTION
This adds support for custom deleters - if the resource managed by a `value_ptr` needs to be deleted differently then this can be used.