### PR TITLE
Fix slicing on reset, copy sequences

### DIFF
--- a/include/value_ptr/value_ptr.h
+++ b/include/value_ptr/value_ptr.h
@@ -202,18 +202,24 @@ public:
    * A call to reset while this object is managing an object will cause the
    * managed object to be destroyed. After calling, this object will manage ptr.
    */
-  void reset(T* ptr = nullptr) noexcept(std::is_nothrow_destructible<T>::value&&
-          std::is_nothrow_copy_constructible<T>::value)
+  template <typename U>
+  void reset(U* ptr) noexcept(std::is_nothrow_destructible<T>::value&&
+          std::is_nothrow_copy_constructible<U>::value)
   {
-    if (impl_) {
-      delete impl_;
-    }
+    delete impl_;
 
     if (ptr) {
-      impl_ = new pmr_model<T>(ptr);
+      impl_ = new pmr_model<U>(ptr);
     } else {
       impl_ = nullptr;
     }
+  }
+
+  void reset(std::nullptr_t = nullptr) noexcept(
+      std::is_nothrow_destructible<T>::value)
+  {
+    delete impl_;
+    impl_ = nullptr;
   }
 
   /**

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(valueptr-unit
+  fixes.cpp
   value_ptr.cpp
   main.cpp)
 

--- a/test/unit/fixes.cpp
+++ b/test/unit/fixes.cpp
@@ -4,17 +4,17 @@
 
 using namespace bsc;
 
+struct slice_base {
+  virtual char f() const { return 'S'; }
+  virtual ~slice_base() {}
+};
+
+struct slice : slice_base {
+  char f() const override { return 'T'; }
+};
+
 TEST_CASE("#15: calling reset then copying slices objects")
 {
-  struct slice_base {
-    virtual char f() const { return 'S'; }
-    virtual ~slice_base() {}
-  };
-
-  struct slice : slice_base {
-    char f() const override { return 'T'; }
-  };
-
   auto ptr = make_val<slice_base>();
   REQUIRE(ptr->f() == 'S');
 

--- a/test/unit/fixes.cpp
+++ b/test/unit/fixes.cpp
@@ -1,0 +1,26 @@
+#include "catch.hpp"
+
+#include <value_ptr/value_ptr.h>
+
+using namespace bsc;
+
+TEST_CASE("#15: calling reset slices objects")
+{
+  struct slice_base {
+    virtual char f() const { return 'S'; }
+    virtual ~slice_base() {}
+  };
+
+  struct slice : slice_base {
+    char f() const override { return 'T'; }
+  };
+
+  auto ptr = make_val<slice_base>();
+  REQUIRE(ptr->f() == 'S');
+
+  ptr.reset(new slice());
+  REQUIRE(ptr->f() == 'T');
+
+  auto p2 = ptr;
+  REQUIRE(p2->f() == 'T');
+}

--- a/test/unit/fixes.cpp
+++ b/test/unit/fixes.cpp
@@ -4,7 +4,7 @@
 
 using namespace bsc;
 
-TEST_CASE("#15: calling reset slices objects")
+TEST_CASE("#15: calling reset then copying slices objects")
 {
   struct slice_base {
     virtual char f() const { return 'S'; }

--- a/test/unit/value_ptr.cpp
+++ b/test/unit/value_ptr.cpp
@@ -366,3 +366,24 @@ TEST_CASE("can convert to unique_pointer")
     REQUIRE(count == 0);
   }
 }
+
+TEST_CASE("calling reset doesn't slice", "[15]")
+{
+  struct slice_base {
+    virtual char f() const { return 'S'; }
+    virtual ~slice_base() {}
+  };
+
+  struct slice : slice_base {
+    char f() const override { return 'T'; }
+  };
+
+  auto ptr = make_val<slice_base>();
+  REQUIRE(ptr->f() == 'S');
+
+  ptr.reset(new slice());
+  REQUIRE(ptr->f() == 'T');
+
+  auto p2 = ptr;
+  REQUIRE(p2->f() == 'T');
+}

--- a/test/unit/value_ptr.cpp
+++ b/test/unit/value_ptr.cpp
@@ -366,24 +366,3 @@ TEST_CASE("can convert to unique_pointer")
     REQUIRE(count == 0);
   }
 }
-
-TEST_CASE("calling reset doesn't slice", "[15]")
-{
-  struct slice_base {
-    virtual char f() const { return 'S'; }
-    virtual ~slice_base() {}
-  };
-
-  struct slice : slice_base {
-    char f() const override { return 'T'; }
-  };
-
-  auto ptr = make_val<slice_base>();
-  REQUIRE(ptr->f() == 'S');
-
-  ptr.reset(new slice());
-  REQUIRE(ptr->f() == 'T');
-
-  auto p2 = ptr;
-  REQUIRE(p2->f() == 'T');
-}


### PR DESCRIPTION
Types were passed incorrectly through `reset`, meaning that a subsequent copy would slice the managed object. This is fixed by templating `reset` to pass the runtime type correctly, and adding an overload for `std::nullptr_t` explicitly.

Fixes #15 