### PR TITLE
`make_derived_val`

### DIFF
--- a/include/value_ptr/value_ptr.h
+++ b/include/value_ptr/value_ptr.h
@@ -362,15 +362,16 @@ void swap(value_ptr<T>& a, value_ptr<T>& b) noexcept
 }
 
 template <typename T, typename... Args>
-auto make_val(Args&&... args) -> value_ptr<T>
+value_ptr<T> make_val(Args&&... args)
 {
   return value_ptr<T>(new T(std::forward<Args>(args)...));
 }
 
 template <typename Base, typename Derived, typename... Args>
-auto make_derived_val(Args&&... args) -> value_ptr<Base>
+typename std::enable_if<std::is_base_of<Base, Derived>::value,
+    value_ptr<Base>>::type
+make_derived_val(Args&&... args)
 {
-  static_assert(
   return value_ptr<Base>(new Derived(std::forward<Args>(args)...));
 }
 
@@ -385,4 +386,5 @@ struct hash<bsc::value_ptr<T>> {
     return std::hash<typename bsc::value_ptr<T>::pointer>()(ptr.get());
   }
 };
+
 } // namespace std

--- a/include/value_ptr/value_ptr.h
+++ b/include/value_ptr/value_ptr.h
@@ -366,6 +366,14 @@ auto make_val(Args&&... args) -> value_ptr<T>
 {
   return value_ptr<T>(new T(std::forward<Args>(args)...));
 }
+
+template <typename Base, typename Derived, typename... Args>
+auto make_derived_val(Args&&... args) -> value_ptr<Base>
+{
+  static_assert(
+  return value_ptr<Base>(new Derived(std::forward<Args>(args)...));
+}
+
 } // namespace bsc
 
 namespace std {

--- a/test/unit/value_ptr.cpp
+++ b/test/unit/value_ptr.cpp
@@ -365,6 +365,45 @@ TEST_CASE("make_val can be used")
   }
 }
 
+struct Base {
+  virtual ~Base() = default;
+  virtual int val() { return 0; }
+};
+
+struct Derived : Base {
+  Derived(int v)
+      : v_(v)
+  {
+  }
+
+  Derived(Derived const& od)
+      : v_(od.v_ + 1)
+  {
+  }
+
+  int val() override { return v_; }
+  int v_;
+};
+
+TEST_CASE("make_derived_val can be used")
+{
+  SECTION("values are propagated")
+  {
+    auto vp = make_derived_val<Base, Derived>(34);
+    REQUIRE(vp->val() == 34);
+  }
+
+  SECTION("derived copies are made")
+  {
+    auto vp = make_derived_val<Base, Derived>(22);
+    REQUIRE(vp->val() == 22);
+
+    auto vp2 = vp;
+    REQUIRE(vp->val() == 22);
+    REQUIRE(vp2->val() == 23);
+  }
+}
+
 TEST_CASE("can convert to unique_pointer")
 {
   SECTION("values are propagated")


### PR DESCRIPTION
Adds a convenience function to construct pointers to a polymorphic base class using a derived class' constructor.